### PR TITLE
Feature endpoint article fix

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,6 @@
   <component name="ChangeListManager">
     <list default="true" id="0864b16b-5c0a-4968-aa34-ce677196accc" name="変更" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/domain/repository/comment_repository.go" beforeDir="false" afterPath="$PROJECT_DIR$/domain/repository/comment_repository.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/domain/repository/tag_repository.go" beforeDir="false" afterPath="$PROJECT_DIR$/domain/repository/tag_repository.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" beforeDir="false" afterPath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="0864b16b-5c0a-4968-aa34-ce677196accc" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/di/user.go" beforeDir="false" afterPath="$PROJECT_DIR$/di/user.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/presentation/controller/user_controller.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/controller/auth_controller.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/presentation/router/router.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/router/router.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/usecase/user_application.go" beforeDir="false" afterPath="$PROJECT_DIR$/usecase/auth_application.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -49,7 +53,7 @@
     <property name="go.modules.go.list.on.any.changes.was.set" value="true" />
     <property name="go.sdk.automatically.set" value="true" />
     <property name="go.watchers.conflict.with.on.save.actions.check.performed" value="true" />
-    <property name="last_opened_file_path" value="$USER_HOME$" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
     <property name="node.js.selected.package.eslint" value="(autodetect)" />
     <property name="node.js.selected.package.standard" value="" />
     <property name="nodejs_interpreter_path.stuck_in_default_project" value="undefined stuck path" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="0864b16b-5c0a-4968-aa34-ce677196accc" name="変更" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/domain/repository/comment_repository.go" beforeDir="false" afterPath="$PROJECT_DIR$/domain/repository/comment_repository.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/domain/repository/tag_repository.go" beforeDir="false" afterPath="$PROJECT_DIR$/domain/repository/tag_repository.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" beforeDir="false" afterPath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -9,6 +9,7 @@
       <change beforePath="$PROJECT_DIR$/domain/repository/article_repository.go" beforeDir="false" afterPath="$PROJECT_DIR$/domain/repository/article_repository.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" beforeDir="false" afterPath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/presentation/controller/article_controller.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/controller/article_controller.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/presentation/request/article.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/request/article.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/presentation/router/router.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/router/router.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/usecase/article_application.go" beforeDir="false" afterPath="$PROJECT_DIR$/usecase/article_application.go" afterDir="false" />
     </list>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,11 +6,11 @@
   <component name="ChangeListManager">
     <list default="true" id="0864b16b-5c0a-4968-aa34-ce677196accc" name="変更" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/di/user.go" beforeDir="false" afterPath="$PROJECT_DIR$/di/user.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/presentation/controller/user_controller.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/controller/auth_controller.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/domain/repository/article_repository.go" beforeDir="false" afterPath="$PROJECT_DIR$/domain/repository/article_repository.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" beforeDir="false" afterPath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/presentation/controller/article_controller.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/controller/article_controller.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/presentation/router/router.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/router/router.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/usecase/user_application.go" beforeDir="false" afterPath="$PROJECT_DIR$/usecase/auth_application.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/usecase/article_application.go" beforeDir="false" afterPath="$PROJECT_DIR$/usecase/article_application.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,12 +6,7 @@
   <component name="ChangeListManager">
     <list default="true" id="0864b16b-5c0a-4968-aa34-ce677196accc" name="変更" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/domain/repository/article_repository.go" beforeDir="false" afterPath="$PROJECT_DIR$/domain/repository/article_repository.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" beforeDir="false" afterPath="$PROJECT_DIR$/infrastructure/mysql_article_persistence.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/presentation/controller/article_controller.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/controller/article_controller.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/presentation/request/article.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/request/article.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/presentation/router/router.go" beforeDir="false" afterPath="$PROJECT_DIR$/presentation/router/router.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/usecase/article_application.go" beforeDir="false" afterPath="$PROJECT_DIR$/usecase/article_application.go" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ go run cmd/main.go
 本リポジトリでは、Qiitaのような記事管理サービスを想定し、あまり触れたことのないライブラリ（chi、orm）の使用と
 **DDD+CQRS**を採用した開発になれることを目的としている．
 
+#### 基本仕様
+- 各エンドポイントのリクエスト&レスポンスは「./docsのsystem-request-response.md」に記載
+- 現時点では、「sign/up」「sign/in」「article/create」を実装ずみ
+
 #### 開発フロー
 - git-flow
 

--- a/di/user.go
+++ b/di/user.go
@@ -13,7 +13,7 @@ func InsertUserDI(router *router.Server) {
 	userQuery := infrastructure.NewUserPersistence(*conn)
 	articleQuery := infrastructure.NewArticlePersistence(*conn)
 
-	userUseCase := usecase.NewUserUseCase(userQuery)
+	userUseCase := usecase.NewAuthUseCase(userQuery)
 	articleUseCase := usecase.NewArticleUseCase(articleQuery)
 
 	useHandler := controller.NewUserHandler(userUseCase)

--- a/domain/repository/article_repository.go
+++ b/domain/repository/article_repository.go
@@ -3,7 +3,7 @@ package repository
 type ArticleRepository interface {
 	CreateNewArticle(articleID, title, description, content, userID string, tags []string) error
 	FixArticle() error
-	DeleteArticle() error
+	DeleteArticle(articleID, userID string) error
 	SearchArticles() error
 	SendArticle() error
 }

--- a/domain/repository/article_repository.go
+++ b/domain/repository/article_repository.go
@@ -1,8 +1,8 @@
 package repository
 
 type ArticleRepository interface {
-	CreateNewArticle(articleID, title, description, content, userID string, tags []string) error
-	FixArticle() error
+	CreateNewArticle(articleID, title, description, content, userID string, tags, images []string) error
+	FixArticle(articleID, title, description, content, userID string, tags, images []string) error
 	DeleteArticle(articleID, userID string) error
 	SearchArticles() error
 	SendArticle() error

--- a/domain/repository/comment_repository.go
+++ b/domain/repository/comment_repository.go
@@ -5,6 +5,6 @@ import "prac-orm-transaction/infrastructure/table"
 type CommentRepository interface {
 	CreateComment(article table.Articles) error
 	DeleteArticle() error
-	SearchComments() error
-	SendComments() error
+	//SearchComments() error
+	//SendComments() error
 }

--- a/domain/repository/tag_repository.go
+++ b/domain/repository/tag_repository.go
@@ -2,7 +2,7 @@ package repository
 
 type TagRepository interface {
 	CreateTag(articleID string, tag []string) error
-	//DeleteTag() error
+	DeleteTag() error
 	//SearchTags() error
 	//SendTags() error
 }

--- a/infrastructure/mysql_article_persistence.go
+++ b/infrastructure/mysql_article_persistence.go
@@ -30,8 +30,10 @@ func (a *articlePersistence) CreateNewArticle(articleID, title, description, con
 	article.Contents = content
 	article.Nice = 0
 
-	str := "INSERT INTO article_tags (`id`,`article_id`,`tag`) VALUES"
-	var s []string
+	bulkInsertTagQuery := "INSERT INTO article_tags (`id`,`article_id`,`tag`) VALUES"
+	bulkInsertImageQuery := "INSERT INTO article_images (`id`,`article_id`,`image`) VALUES"
+	var bulkInsertTag []string
+	var bulkInsertImage []string
 	var queryEnd string
 
 	for i, tag := range tags {
@@ -46,10 +48,25 @@ func (a *articlePersistence) CreateNewArticle(articleID, title, description, con
 			return err
 		}
 		q := fmt.Sprintf("('%s', '%s','%s')%s", tagID.String(), articleID, tag, queryEnd)
-		s = append(s, q)
+		bulkInsertTag = append(bulkInsertTag, q)
 	}
+	bulkInsertTagQuery += strings.Join(bulkInsertTag, "")
 
-	query := strings.Join(s, "")
+	for i, image := range images {
+		if len(images)-1 == i {
+			queryEnd = ";"
+		} else {
+			queryEnd = ","
+		}
+		imageID, err := uuid.NewRandom()
+		if err != nil {
+			log.Println(err)
+			return err
+		}
+		q := fmt.Sprintf("('%s', '%s','%s')%s", imageID.String(), articleID, image, queryEnd)
+		bulkInsertImage = append(bulkInsertImage, q)
+	}
+	bulkInsertImageQuery += strings.Join(bulkInsertImage, "")
 
 	err := a.mysql.Client.Transaction(func(tx *gorm.DB) error {
 		//記事を追加
@@ -58,7 +75,12 @@ func (a *articlePersistence) CreateNewArticle(articleID, title, description, con
 			return err
 		}
 		//タグを追加
-		if err := tx.Exec(str + query).Error; err != nil {
+		if err := tx.Exec(bulkInsertTagQuery).Error; err != nil {
+			log.Println(err)
+			return err
+		}
+		//画像を追加
+		if err := tx.Exec(bulkInsertImageQuery).Error; err != nil {
 			log.Println(err)
 			return err
 		}
@@ -76,12 +98,8 @@ func (a *articlePersistence) CreateNewArticle(articleID, title, description, con
 
 func (a *articlePersistence) FixArticle(articleID, title, description, content, userID string, tags, images []string) error {
 	var article table.Articles
+
 	if err := a.mysql.Client.Raw("SELECT * FROM articles WHERE id = ? AND user_id = ?", articleID, userID).Scan(&article).Error; err != nil {
-		log.Println(err)
-		return err
-	}
-	if article.Title == "" {
-		err := errors.New("this request user has not this article.")
 		log.Println(err)
 		return err
 	}
@@ -97,6 +115,85 @@ func (a *articlePersistence) FixArticle(articleID, title, description, content, 
 	if description != "" {
 		article.Description = description
 	}
+
+	if article.Title == "" {
+		err := errors.New("this request user has not this article.")
+		log.Println(err)
+		return err
+	}
+	if len(tags) > 0 {
+		bulkInsertTagQuery := "INSERT INTO article_tags (`id`,`article_id`,`tag`) VALUES"
+		var bulkInsertTag []string
+		var queryEnd string
+
+		for i, tag := range tags {
+			if len(tags)-1 == i {
+				queryEnd = ";"
+			} else {
+				queryEnd = ","
+			}
+			tagID, err := uuid.NewRandom()
+			if err != nil {
+				log.Println(err)
+				return err
+			}
+			q := fmt.Sprintf("('%s', '%s','%s')%s", tagID.String(), articleID, tag, queryEnd)
+			bulkInsertTag = append(bulkInsertTag, q)
+		}
+		bulkInsertTagQuery += strings.Join(bulkInsertTag, "")
+
+		a.mysql.Client.Transaction(func(tx *gorm.DB) error {
+			var deleteTag table.ArticleTag
+			deleteTag.ArticleID = articleID
+			if err := tx.Delete(&deleteTag).Error; err != nil {
+				log.Println(err)
+				return err
+			}
+
+			if err := tx.Exec(bulkInsertTagQuery).Error; err != nil {
+				log.Println(err)
+				return err
+			}
+			return nil
+		})
+	}
+
+	if len(images) > 0 {
+		bulkInsertImageQuery := "INSERT INTO article_images (`id`,`article_id`,`image`) VALUES"
+		var bulkInsertImage []string
+		var queryEnd string
+
+		for i, image := range images {
+			if len(images)-1 == i {
+				queryEnd = ";"
+			} else {
+				queryEnd = ","
+			}
+			imageID, err := uuid.NewRandom()
+			if err != nil {
+				log.Println(err)
+				return err
+			}
+			q := fmt.Sprintf("('%s', '%s','%s')%s", imageID.String(), articleID, image, queryEnd)
+			bulkInsertImage = append(bulkInsertImage, q)
+		}
+		bulkInsertImageQuery += strings.Join(bulkInsertImage, "")
+
+		a.mysql.Client.Transaction(func(tx *gorm.DB) error {
+			var deleteImage table.ArticleImage
+			deleteImage.ArticleID = articleID
+			if err := tx.Delete(&deleteImage).Error; err != nil {
+				log.Println(err)
+				return err
+			}
+			if err := tx.Exec(bulkInsertImageQuery).Error; err != nil {
+				log.Println(err)
+				return err
+			}
+			return nil
+		})
+	}
+
 	if err := a.mysql.Client.Save(&article).Error; err != nil {
 		log.Println(err)
 		return err
@@ -107,6 +204,11 @@ func (a *articlePersistence) FixArticle(articleID, title, description, content, 
 
 func (a *articlePersistence) DeleteArticle(articleID, userID string) error {
 	var article table.Articles
+	var image table.ArticleImage
+	var tag table.ArticleTag
+	image.ArticleID = articleID
+	tag.ArticleID = articleID
+
 	if err := a.mysql.Client.Raw("SELECT * FROM articles WHERE id = ? AND user_id = ?", articleID, userID).Scan(&article).Error; err != nil {
 		log.Println(err)
 		return err
@@ -117,10 +219,22 @@ func (a *articlePersistence) DeleteArticle(articleID, userID string) error {
 		return err
 	}
 
-	if err := a.mysql.Client.Delete(&article).Error; err != nil {
-		log.Println(err)
-		return err
-	}
+	a.mysql.Client.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(&article).Error; err != nil {
+			log.Println(err)
+			return err
+		}
+		if err := tx.Delete(&image).Error; err != nil {
+			log.Println(err)
+			return err
+		}
+		if err := tx.Delete(&tag).Error; err != nil {
+			log.Println(err)
+			return err
+		}
+		return nil
+	})
+
 	return nil
 }
 

--- a/infrastructure/mysql_article_persistence.go
+++ b/infrastructure/mysql_article_persistence.go
@@ -97,7 +97,6 @@ func (a *articlePersistence) FixArticle(articleID, title, description, content, 
 	if description != "" {
 		article.Description = description
 	}
-	log.Println("aa")
 	if err := a.mysql.Client.Save(&article).Error; err != nil {
 		log.Println(err)
 		return err

--- a/infrastructure/mysql_article_persistence.go
+++ b/infrastructure/mysql_article_persistence.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"errors"
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
@@ -77,7 +78,22 @@ func (a *articlePersistence) FixArticle() error {
 	return nil
 }
 
-func (a *articlePersistence) DeleteArticle() error {
+func (a *articlePersistence) DeleteArticle(articleID, userID string) error {
+	var article table.Articles
+	if err := a.mysql.Client.Raw("SELECT * FROM articles WHERE id = ? AND user_id = ?", articleID, userID).Scan(&article).Error; err != nil {
+		log.Println(err)
+		return err
+	}
+	if article.Title == "" {
+		err := errors.New("this request user has not this article.")
+		log.Println(err)
+		return err
+	}
+
+	if err := a.mysql.Client.Delete(&article).Error; err != nil {
+		log.Println(err)
+		return err
+	}
 	return nil
 }
 

--- a/infrastructure/mysql_article_persistence.go
+++ b/infrastructure/mysql_article_persistence.go
@@ -21,7 +21,7 @@ func NewArticlePersistence(mysqlConn mysqlRepository) repository.ArticleReposito
 	return &articlePersistence{mysql: mysqlConn}
 }
 
-func (a *articlePersistence) CreateNewArticle(articleID, title, description, content, userID string, tags []string) error {
+func (a *articlePersistence) CreateNewArticle(articleID, title, description, content, userID string, tags, images []string) error {
 	var article table.Articles
 	article.ID = articleID
 	article.Title = title
@@ -74,7 +74,35 @@ func (a *articlePersistence) CreateNewArticle(articleID, title, description, con
 	return nil
 }
 
-func (a *articlePersistence) FixArticle() error {
+func (a *articlePersistence) FixArticle(articleID, title, description, content, userID string, tags, images []string) error {
+	var article table.Articles
+	if err := a.mysql.Client.Raw("SELECT * FROM articles WHERE id = ? AND user_id = ?", articleID, userID).Scan(&article).Error; err != nil {
+		log.Println(err)
+		return err
+	}
+	if article.Title == "" {
+		err := errors.New("this request user has not this article.")
+		log.Println(err)
+		return err
+	}
+
+	if content != "" {
+		article.Contents = content
+	}
+
+	if title != "" {
+		article.Title = title
+	}
+
+	if description != "" {
+		article.Description = description
+	}
+	log.Println("aa")
+	if err := a.mysql.Client.Save(&article).Error; err != nil {
+		log.Println(err)
+		return err
+	}
+
 	return nil
 }
 

--- a/presentation/controller/article_controller.go
+++ b/presentation/controller/article_controller.go
@@ -13,7 +13,7 @@ import (
 
 type ArticleHandler interface {
 	CreateArticle() http.HandlerFunc
-	//FixArticle() http.HandlerFunc
+	FixArticle() http.HandlerFunc
 	DeleteArticle() http.HandlerFunc
 	//SearchArticles() http.HandlerFunc
 	//SendArticles() http.HandlerFunc
@@ -62,17 +62,29 @@ func (ah *articleHandler) CreateArticle() http.HandlerFunc {
 
 func (ah *articleHandler) FixArticle() http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
+		userID := request.Header.Get("userID")
+		articleID := request.Header.Get("ArticleID")
+		var images []string
+		var tags []string
+
 		// リクエストBodyから更新後情報を取得
 		var fixArticleRequest request2.FixArticleRequest
 		json.NewDecoder(request.Body).Decode(&fixArticleRequest)
-
-		if fixArticleRequest.Id == "" {
+		if fixArticleRequest.Content == "" || fixArticleRequest.Title == "" || fixArticleRequest.Description == "" {
 			log.Println("[ERROR] request bucket is err")
 			response.RespondError(writer, http.StatusBadRequest, fmt.Errorf("リクエスト情報が不足しています"))
 			return
 		}
 
-		articleID, err := ah.articleUseCase.FixArticle(fixArticleRequest)
+		for _, image := range fixArticleRequest.Images {
+			images = append(images, image.Image)
+		}
+		for _, tag := range fixArticleRequest.Tags {
+			tags = append(tags, tag.Tag)
+		}
+
+		err := ah.articleUseCase.FixArticle(fixArticleRequest.Title, fixArticleRequest.Description,
+			fixArticleRequest.Content, userID, articleID, images, tags)
 		if err != nil {
 			response.RespondError(writer, http.StatusInternalServerError, err)
 			return
@@ -86,7 +98,7 @@ func (ah *articleHandler) DeleteArticle() http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
 		// リクエストBodyから更新後情報を取得
 		userID := request.Header.Get("userID")
-		articleID := request.Header.Get("articleID")
+		articleID := request.Header.Get("ArticleID")
 
 		if articleID == "" {
 			response.RespondError(writer, http.StatusInternalServerError, errors.New("request  is error"))

--- a/presentation/controller/article_controller.go
+++ b/presentation/controller/article_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -13,7 +14,7 @@ import (
 type ArticleHandler interface {
 	CreateArticle() http.HandlerFunc
 	//FixArticle() http.HandlerFunc
-	//DeleteArticle() http.HandlerFunc
+	DeleteArticle() http.HandlerFunc
 	//SearchArticles() http.HandlerFunc
 	//SendArticles() http.HandlerFunc
 }
@@ -78,5 +79,26 @@ func (ah *articleHandler) FixArticle() http.HandlerFunc {
 		}
 
 		writer.Write([]byte(articleID))
+	}
+}
+
+func (ah *articleHandler) DeleteArticle() http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		// リクエストBodyから更新後情報を取得
+		userID := request.Header.Get("userID")
+		articleID := request.Header.Get("articleID")
+
+		if articleID == "" {
+			response.RespondError(writer, http.StatusInternalServerError, errors.New("request  is error"))
+			return
+		}
+
+		err := ah.articleUseCase.DeleteArticle(articleID, userID)
+		if err != nil {
+			response.RespondError(writer, http.StatusInternalServerError, err)
+			return
+		}
+
+		writer.Write([]byte("delete success"))
 	}
 }

--- a/presentation/controller/auth_controller.go
+++ b/presentation/controller/auth_controller.go
@@ -10,20 +10,20 @@ import (
 	"prac-orm-transaction/usecase"
 )
 
-type UserHandler interface {
-	CreateUserAccount() http.HandlerFunc
+type AuthHandler interface {
+	SignUp() http.HandlerFunc
 	SignIn() http.HandlerFunc
 }
 
-type userHandler struct {
-	userUseCase usecase.UserUseCase
+type authHandler struct {
+	authUseCase usecase.AuthUseCase
 }
 
-func NewUserHandler(userUseCase usecase.UserUseCase) *userHandler {
-	return &userHandler{userUseCase: userUseCase}
+func NewUserHandler(authUseCase usecase.AuthUseCase) *authHandler {
+	return &authHandler{authUseCase: authUseCase}
 }
 
-func (uh *userHandler) CreateUserAccount() http.HandlerFunc {
+func (uh *authHandler) SignUp() http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
 		// リクエストBodyから更新後情報を取得
 		var accountInfo request2.CreateUserAccountRequest
@@ -35,7 +35,7 @@ func (uh *userHandler) CreateUserAccount() http.HandlerFunc {
 			return
 		}
 
-		token, err := uh.userUseCase.CreateUserAccount(accountInfo.ID, accountInfo.Pass)
+		token, err := uh.authUseCase.SignUp(accountInfo.ID, accountInfo.Pass)
 		if err != nil {
 			response.RespondError(writer, http.StatusInternalServerError, err)
 			return
@@ -45,7 +45,7 @@ func (uh *userHandler) CreateUserAccount() http.HandlerFunc {
 	}
 }
 
-func (uh *userHandler) SignIn() http.HandlerFunc {
+func (uh *authHandler) SignIn() http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
 		// リクエストBodyから更新後情報を取得
 		var accountInfo request2.CreateUserAccountRequest
@@ -57,7 +57,7 @@ func (uh *userHandler) SignIn() http.HandlerFunc {
 			return
 		}
 
-		token, err := uh.userUseCase.SignIn(accountInfo.ID, accountInfo.Pass)
+		token, err := uh.authUseCase.SignIn(accountInfo.ID, accountInfo.Pass)
 		if err != nil {
 			response.RespondError(writer, http.StatusInternalServerError, err)
 			return

--- a/presentation/request/article.go
+++ b/presentation/request/article.go
@@ -9,12 +9,11 @@ type CreateArticleRequest struct {
 }
 
 type FixArticleRequest struct {
-	Id          string   `json:"article_id"`
-	Title       string   `json:"title"`
-	Description string   `json:"description"`
-	Content     string   `json:"content"`
-	Images      []string `json:"images"`
-	Tags        []tag    `json:"tags"`
+	Title       string  `json:"title"`
+	Description string  `json:"description"`
+	Content     string  `json:"content"`
+	Images      []image `json:"images"`
+	Tags        []tag   `json:"tags"`
 }
 
 type image struct {

--- a/presentation/router/router.go
+++ b/presentation/router/router.go
@@ -38,9 +38,7 @@ func (s *Server) Routing(uh controller.AuthHandler, ah controller.ArticleHandler
 			create.Post("/", ah.CreateArticle())
 		})
 		api.Route("/fix", func(fix chi.Router) {
-			fix.Put("/", func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte("fix"))
-			})
+			fix.Put("/", ah.FixArticle())
 		})
 		api.Route("/search", func(search chi.Router) {
 			search.Put("/", func(w http.ResponseWriter, r *http.Request) {

--- a/presentation/router/router.go
+++ b/presentation/router/router.go
@@ -47,6 +47,9 @@ func (s *Server) Routing(uh controller.AuthHandler, ah controller.ArticleHandler
 				w.Write([]byte("search"))
 			})
 		})
+		api.Route("/delete", func(delete chi.Router) {
+			delete.Delete("/", ah.DeleteArticle())
+		})
 	})
 
 	s.Router.Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/presentation/router/router.go
+++ b/presentation/router/router.go
@@ -20,12 +20,12 @@ func NewServer() *Server {
 }
 
 // Router ルーティング設定
-func (s *Server) Routing(uh controller.UserHandler, ah controller.ArticleHandler) {
+func (s *Server) Routing(uh controller.AuthHandler, ah controller.ArticleHandler) {
 	s.Router.Use(middleware.Timeout(60 * time.Second))
 	s.Router.Use(middleware.Logger)
 	s.Router.Route("/sign", func(api chi.Router) {
 		api.Route("/up", func(signup chi.Router) {
-			signup.Post("/", uh.CreateUserAccount())
+			signup.Post("/", uh.SignUp())
 		})
 		api.Route("/in", func(signin chi.Router) {
 			signin.Post("/", uh.SignIn())

--- a/usecase/article_application.go
+++ b/usecase/article_application.go
@@ -10,7 +10,7 @@ import (
 type ArticleUseCase interface {
 	CreateArticle(title, description, content, userID string, images, tags []string) (string, error)
 	FixArticle(request.FixArticleRequest) (string, error)
-	DeleteArticle(id, pass string) error
+	DeleteArticle(articleID, userID string) error
 	SearchArticle(id, pass string) (string, error)
 	SearchArticles(id, pass string) (string, error)
 	SendArticles(id, pass string) (string, error)
@@ -48,9 +48,12 @@ func (au articleUseCase) FixArticle(request.FixArticleRequest) (string, error) {
 	panic("implement me")
 }
 
-func (au articleUseCase) DeleteArticle(id, pass string) error {
-	//TODO implement me
-	panic("implement me")
+func (au articleUseCase) DeleteArticle(articleID, userID string) error {
+	if err := au.article.DeleteArticle(articleID, userID); err != nil {
+		log.Println(err)
+		return err
+	}
+	return nil
 }
 
 func (au articleUseCase) SearchArticle(id, pass string) (string, error) {

--- a/usecase/article_application.go
+++ b/usecase/article_application.go
@@ -4,12 +4,11 @@ import (
 	"github.com/google/uuid"
 	"log"
 	"prac-orm-transaction/domain/repository"
-	"prac-orm-transaction/presentation/request"
 )
 
 type ArticleUseCase interface {
 	CreateArticle(title, description, content, userID string, images, tags []string) (string, error)
-	FixArticle(request.FixArticleRequest) (string, error)
+	FixArticle(title, description, content, userID, articleID string, images, tags []string) error
 	DeleteArticle(articleID, userID string) error
 	SearchArticle(id, pass string) (string, error)
 	SearchArticles(id, pass string) (string, error)
@@ -35,7 +34,7 @@ func (au articleUseCase) CreateArticle(title, description, content, userID strin
 	}
 
 	articleID = uuid.String()
-	if err = au.article.CreateNewArticle(articleID, title, description, content, userID, tags); err != nil {
+	if err = au.article.CreateNewArticle(articleID, title, description, content, userID, tags, images); err != nil {
 		log.Println(err)
 		return articleID, err
 	}
@@ -43,9 +42,12 @@ func (au articleUseCase) CreateArticle(title, description, content, userID strin
 	return articleID, err
 }
 
-func (au articleUseCase) FixArticle(request.FixArticleRequest) (string, error) {
-	//TODO implement me
-	panic("implement me")
+func (au articleUseCase) FixArticle(title, description, content, userID, articleID string, images, tags []string) error {
+	if err := au.article.FixArticle(articleID, title, description, content, userID, tags, images); err != nil {
+		log.Println(err)
+		return err
+	}
+	return nil
 }
 
 func (au articleUseCase) DeleteArticle(articleID, userID string) error {

--- a/usecase/auth_application.go
+++ b/usecase/auth_application.go
@@ -6,20 +6,20 @@ import (
 	"prac-orm-transaction/domain/repository"
 )
 
-type UserUseCase interface {
-	CreateUserAccount(id, pass string) (string, error)
+type AuthUseCase interface {
+	SignUp(id, pass string) (string, error)
 	SignIn(id, pass string) (string, error)
 }
 
-type userUseCase struct {
+type authUseCase struct {
 	user repository.UserRepository
 }
 
-func NewUserUseCase(user repository.UserRepository) *userUseCase {
-	return &userUseCase{user: user}
+func NewAuthUseCase(user repository.UserRepository) *authUseCase {
+	return &authUseCase{user: user}
 }
 
-func (uu userUseCase) CreateUserAccount(id, pass string) (string, error) {
+func (uu authUseCase) SignUp(id, pass string) (string, error) {
 	var token string
 
 	uuid, err := uuid.NewRandom()
@@ -38,7 +38,7 @@ func (uu userUseCase) CreateUserAccount(id, pass string) (string, error) {
 	return token, nil
 }
 
-func (uu userUseCase) SignIn(id, pass string) (string, error) {
+func (uu authUseCase) SignIn(id, pass string) (string, error) {
 	var token string
 
 	uuid, err := uuid.NewRandom()


### PR DESCRIPTION
# このプルリクは何か？
エンドポイント
- article/create
- article/fix
- article/delete
を実装した

# 対応内容
各エンドポイント(記事周り)の機能を実装した。  
Mysqlのクエリの発行回数を最低限にするためにバルクインサートを使用した。  
エラーハンドリング、トランザクションが必要／不必要をきちんと考慮した。

# テスト方法
Readmeに記載されている手順でプログラムを実行する (http://localhost:8000/)
- /sign/up でアカウントを作成
- /sign/in で作成済みのアカウントを使用してトークンを再発行
- /artilce/createで記事を作成
- /artilce/fixで記事を修正
- /artilce/deleteで記事を削除
(基本的にリクエストはdocsを参照する)

# 課題
現状認証tokenをuudiで生成しているが、後々jwtなどを採用し時間制限を設ける必要がある  
時間があればいろいろな認証を試してみたい    
インフラ部分のコードがファットコードになってきた